### PR TITLE
REST principles and transaction improvement

### DIFF
--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -32,7 +32,7 @@ export class ProfileComponent implements OnInit {
   }
 
   ngOnInit() {
-    let url = 'http://localhost:8080/session/login';
+    let url = 'http://localhost:8080/auth/login';
     let token: string = sessionStorage.getItem('token');
     if (token != null && token != '') {
       let headers: HttpHeaders = new HttpHeaders({

--- a/src/app/service/admin.service.ts
+++ b/src/app/service/admin.service.ts
@@ -23,7 +23,7 @@ export class AdminService {
   }
 
   public banUser(user: User): Observable<User> {
-    return this.http.get<User>(this.usersUrl + '/ban/' + user.id, {headers: this.headers});
+    return this.http.patch<User>(this.usersUrl + '/ban/' + user.id, {},{headers: this.headers});
   }
 
   public acceptIngredient(ingredient: AdminIngredient): Observable<AdminIngredient> {

--- a/src/app/service/auth.service.ts
+++ b/src/app/service/auth.service.ts
@@ -32,7 +32,7 @@ export class AuthService {
       authorization: 'Basic ' + btoa(credentials.username + ':' + credentials.password)
     } : {});
 
-    let url = 'http://localhost:8080/session/login';
+    let url = 'http://localhost:8080/auth/login';
     this.http.get<Observable<Object>>(url, {headers: headers}).subscribe(
       response => {
         if (response['name']) {
@@ -62,7 +62,7 @@ export class AuthService {
       authorization: 'Basic ' + sessionStorage.getItem('token')
     });
 
-    this.http.get('http://localhost:8080/session/logout', {headers: headers}).pipe(
+    this.http.get('http://localhost:8080/auth/logout', {headers: headers}).pipe(
       finalize(() => {
         this.authenticated = false;
         this.role = 'USER';
@@ -76,7 +76,7 @@ export class AuthService {
     const headers = new HttpHeaders({
       authorization: 'Basic ' + token
     });
-    let url = 'http://localhost:8080/session/login';
+    let url = 'http://localhost:8080/auth/login';
 
     this.http.get<Observable<Object>>(url, {headers: headers}).subscribe(
       response => {
@@ -94,7 +94,7 @@ export class AuthService {
   }
 
   public getPrincipal(): Observable<Object> {
-    let url = 'http://localhost:8080/session/login';
+    let url = 'http://localhost:8080/auth/login';
     const headers = new HttpHeaders({
       authorization: 'Basic ' + sessionStorage.getItem('token')
     });

--- a/src/main/java/nl/hr/recipefinder/config/SecurityConfig.java
+++ b/src/main/java/nl/hr/recipefinder/config/SecurityConfig.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import lombok.RequiredArgsConstructor;
 import nl.hr.recipefinder.security.Role;
-import nl.hr.recipefinder.service.SessionService;
+import nl.hr.recipefinder.service.AuthenticationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -25,13 +25,13 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-  private final SessionService sessionService;
+  private final AuthenticationService authenticationService;
 
   @Bean
   protected AuthenticationProvider authenticationProvider(PasswordEncoder encoder) {
     DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
     provider.setPasswordEncoder(encoder);
-    provider.setUserDetailsService(sessionService);
+    provider.setUserDetailsService(authenticationService);
 
     return provider;
   }

--- a/src/main/java/nl/hr/recipefinder/controller/AdminController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/AdminController.java
@@ -1,16 +1,19 @@
 package nl.hr.recipefinder.controller;
 
+import lombok.RequiredArgsConstructor;
 import nl.hr.recipefinder.model.dto.AdminIngredientDto;
 import nl.hr.recipefinder.model.entity.Ingredient;
 import nl.hr.recipefinder.service.IngredientService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
+@RequiredArgsConstructor
 @CrossOrigin(origins = "localhost:4200",
   allowedHeaders = {"x-auth-token", "x-requested-with", "x-xsrf-token", "authorization", "content-type", "accept"})
 @RequestMapping("/admin")
@@ -18,21 +21,11 @@ public class AdminController {
   private final IngredientService ingredientService;
   private final ModelMapper modelMapper;
 
-  @Autowired
-  public AdminController(
-    IngredientService ingredientService,
-    ModelMapper modelMapper
-  ) {
-    this.ingredientService = ingredientService;
-    this.modelMapper = modelMapper;
-  }
-
-
+  @Transactional
   @PatchMapping("/ingredients")
   public Ingredient updateIngredientState(@RequestBody AdminIngredientDto ingredient) {
     return ingredientService.update(modelMapper.map(ingredient, Ingredient.class));
   }
-
 
   @GetMapping("/ingredients/refused")
   public List<AdminIngredientDto> getRefusedIngredients() {
@@ -41,7 +34,6 @@ public class AdminController {
       modelMapper.map(it, AdminIngredientDto.class)
     ).collect(Collectors.toList());
   }
-
 
   @GetMapping("/ingredients/pending")
   public List<AdminIngredientDto> getPendingIngredients() {

--- a/src/main/java/nl/hr/recipefinder/controller/AuthenticationController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/AuthenticationController.java
@@ -16,10 +16,9 @@ import java.security.Principal;
 @RestController
 @CrossOrigin(origins = "localhost:4200",
   allowedHeaders = {"x-auth-token", "x-requested-with", "x-xsrf-token", "authorization", "content-type", "accept"})
-@RequestMapping("/session")
-public class SessionController {
+@RequestMapping("/auth")
+public class AuthenticationController {
 
-  @Transactional
   @GetMapping("/login")
   public Principal user(Principal user) {
     return user;

--- a/src/main/java/nl/hr/recipefinder/controller/FavoritesListController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/FavoritesListController.java
@@ -11,10 +11,11 @@ import nl.hr.recipefinder.model.httpexception.clienterror.HttpUnauthorizedExcept
 import nl.hr.recipefinder.service.FavoritesListRecipeService;
 import nl.hr.recipefinder.service.FavoritesListService;
 import nl.hr.recipefinder.service.RecipeService;
-import nl.hr.recipefinder.service.SessionService;
+import nl.hr.recipefinder.service.AuthenticationService;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.ConstraintViolationException;
@@ -29,12 +30,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @RequestMapping()
 public class FavoritesListController {
-  private final SessionService sessionService;
+  private final AuthenticationService authenticationService;
   private final FavoritesListService favoritesListService;
   private final FavoritesListRecipeService favoritesListRecipeService;
   private final RecipeService recipeService;
   private final ModelMapper modelMapper;
-
 
   @GetMapping("/user/{userId}/favorites")
   public ResponseEntity<List<FavoritesListResponseDto>> getAllByUser(@PathVariable Long userId) {
@@ -55,10 +55,11 @@ public class FavoritesListController {
     return new ResponseEntity<>(favoritesListDto, HttpStatus.OK);
   }
 
+  @Transactional
   @PostMapping("/user/{userId}/favorites/{favoritesListId}")
   public ResponseEntity<FavoritesListResponseDto> addFavorite(@RequestBody Long recipeId, @PathVariable("userId") Long userId, @PathVariable("favoritesListId") Long favoritesListId) {
     try {
-      User activeUser = sessionService.getAuthenticatedUser();
+      User activeUser = authenticationService.getAuthenticatedUser();
 
       if (!activeUser.getId().equals(userId)) {
         throw new HttpUnauthorizedException();
@@ -86,10 +87,11 @@ public class FavoritesListController {
     }
   }
 
+  @Transactional
   @PostMapping("/user/{userId}/favorites")
   public ResponseEntity<FavoritesListResponseDto> createFavoritesList(@RequestBody FavoritesListRequestDto favoritesListDto, @PathVariable("userId") Long userId) {
     try {
-      User activeUser = sessionService.getAuthenticatedUser();
+      User activeUser = authenticationService.getAuthenticatedUser();
 
       if (!activeUser.getId().equals(userId)) {
         throw new HttpUnauthorizedException();

--- a/src/main/java/nl/hr/recipefinder/controller/IngredientController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/IngredientController.java
@@ -1,16 +1,19 @@
 package nl.hr.recipefinder.controller;
 
+import lombok.RequiredArgsConstructor;
 import nl.hr.recipefinder.model.dto.IngredientDto;
 import nl.hr.recipefinder.model.entity.Ingredient;
 import nl.hr.recipefinder.service.IngredientService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
+@RequiredArgsConstructor
 @CrossOrigin(origins = "localhost:4200",
   allowedHeaders = {"x-auth-token", "x-requested-with", "x-xsrf-token", "authorization", "content-type", "accept"})
 @RequestMapping("/ingredient")
@@ -18,13 +21,7 @@ public class IngredientController {
   private final IngredientService ingredientService;
   private final ModelMapper modelMapper;
 
-  @Autowired
-  public IngredientController(IngredientService ingredientService, ModelMapper modelMapper) {
-    this.ingredientService = ingredientService;
-    this.modelMapper = modelMapper;
-  }
-
-
+  @Transactional
   @PostMapping()
   public List<Ingredient> createIngredients(@RequestBody List<IngredientDto> ingredientDtos) {
     List<Ingredient> mappedIngredients = ingredientDtos.stream()
@@ -33,7 +30,6 @@ public class IngredientController {
 
     return ingredientService.findOrCreateIngredients(mappedIngredients);
   }
-
 
   @GetMapping("/search/{searchInput}")
   public List<IngredientDto> searchIngredients(@PathVariable String searchInput) {

--- a/src/main/java/nl/hr/recipefinder/controller/PictureController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/PictureController.java
@@ -1,5 +1,6 @@
 package nl.hr.recipefinder.controller;
 
+import lombok.RequiredArgsConstructor;
 import nl.hr.recipefinder.model.dto.PictureDto;
 import nl.hr.recipefinder.model.entity.Picture;
 import nl.hr.recipefinder.model.httpexception.clienterror.HttpNotFoundError;
@@ -16,22 +17,13 @@ import java.util.Optional;
 
 
 @RestController
+@RequiredArgsConstructor
 @CrossOrigin(origins = "localhost:4200",
   allowedHeaders = {"x-auth-token", "x-requested-with", "x-xsrf-token", "authorization", "content-type", "accept"})
 @RequestMapping("/picture")
 public class PictureController {
-
-
   private final PictureService pictureService;
-
-  final ModelMapper modelMapper;
-
-  @Autowired
-  public PictureController(PictureService pictureService, ModelMapper modelMapper) {
-    this.pictureService = pictureService;
-    this.modelMapper = modelMapper;
-  }
-
+  private final ModelMapper modelMapper;
 
   @GetMapping()
   public List<PictureDto> downloadFiles() {

--- a/src/main/java/nl/hr/recipefinder/controller/RecipeIngredientController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/RecipeIngredientController.java
@@ -1,5 +1,6 @@
 package nl.hr.recipefinder.controller;
 
+import lombok.RequiredArgsConstructor;
 import nl.hr.recipefinder.model.dto.RecipeIngredientDto;
 import nl.hr.recipefinder.model.entity.RecipeIngredient;
 import nl.hr.recipefinder.model.httpexception.clienterror.HttpConflictError;
@@ -11,27 +12,21 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
+@RequiredArgsConstructor
 @CrossOrigin(origins = "localhost:4200",
   allowedHeaders = {"x-auth-token", "x-requested-with", "x-xsrf-token", "authorization", "content-type", "accept"})
 @RequestMapping("/recipeIngredient")
 public class RecipeIngredientController {
 
   private final RecipeIngredientService recipeIngredientService;
-  final ModelMapper modelMapper;
+  private final ModelMapper modelMapper;
 
-  @Autowired
-  public RecipeIngredientController(
-    RecipeIngredientService recipeIngredientService,
-    ModelMapper modelMapper
-  ) {
-    this.recipeIngredientService = recipeIngredientService;
-    this.modelMapper = modelMapper;
-  }
-
+  @Transactional
   @PostMapping()
   public ResponseEntity<List<RecipeIngredient>> createIngredients(@RequestBody List<RecipeIngredientDto> recipeIngredients) {
     try {

--- a/src/main/java/nl/hr/recipefinder/controller/ReviewController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package nl.hr.recipefinder.controller;
 
+import lombok.RequiredArgsConstructor;
 import nl.hr.recipefinder.model.dto.ReviewDto;
 import nl.hr.recipefinder.model.dto.ReviewResponseDto;
 import nl.hr.recipefinder.model.dto.UserResponseDto;
@@ -7,9 +8,8 @@ import nl.hr.recipefinder.model.entity.Review;
 import nl.hr.recipefinder.model.entity.User;
 import nl.hr.recipefinder.model.httpexception.clienterror.HttpBadRequestError;
 import nl.hr.recipefinder.service.ReviewService;
-import nl.hr.recipefinder.service.SessionService;
+import nl.hr.recipefinder.service.AuthenticationService;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,21 +18,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @CrossOrigin(origins = "localhost:4200",
   allowedHeaders = {"x-auth-token", "x-requested-with", "x-xsrf-token", "authorization", "content-type", "accept"})
 @RequestMapping()
 public class ReviewController {
-
   private final ReviewService reviewService;
-  private final SessionService sessionService;
+  private final AuthenticationService authenticationService;
   private final ModelMapper modelMapper;
-
-  @Autowired
-  public ReviewController(ReviewService reviewService, SessionService sessionService, ModelMapper modelMapper) {
-    this.reviewService = reviewService;
-    this.sessionService = sessionService;
-    this.modelMapper = modelMapper;
-  }
 
   @GetMapping("/recipe/{recipeId}/review")
   public ResponseEntity<List<ReviewResponseDto>> getReviewsForOneRecipe(@PathVariable("recipeId") Long recipeId){
@@ -45,7 +38,7 @@ public class ReviewController {
   @PostMapping("/recipe/{recipeId}/review")
   public ResponseEntity<ReviewResponseDto> createReview(@RequestBody ReviewDto reviewDto, @PathVariable("recipeId") Long recipeId){
     try{
-      User currentUser = sessionService.getAuthenticatedUser();
+      User currentUser = authenticationService.getAuthenticatedUser();
 
       Review mappedReview = modelMapper.map(reviewDto, Review.class);
       mappedReview.setUser(currentUser);

--- a/src/main/java/nl/hr/recipefinder/controller/UserController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/UserController.java
@@ -53,7 +53,8 @@ public class UserController {
         }
     }
 
-    @GetMapping("/ban/{id}")
+    @Transactional
+    @PatchMapping("/ban/{id}")
     public ResponseEntity<Boolean> banUser(@PathVariable Long id) {
         try {
             Optional<User> foundUser = userService.findUserById(id);

--- a/src/main/java/nl/hr/recipefinder/controller/UserController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/UserController.java
@@ -19,6 +19,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -88,6 +89,7 @@ public class UserController {
         }
     }
 
+    @Transactional
     @PostMapping()
     public ResponseEntity<User> createUser(@RequestBody UserRequestDto userRequestDto) {
         User mappedUser = modelMapper.map(userRequestDto, User.class);

--- a/src/main/java/nl/hr/recipefinder/service/AuthenticationService.java
+++ b/src/main/java/nl/hr/recipefinder/service/AuthenticationService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class SessionService implements UserDetailsService {
+public class AuthenticationService implements UserDetailsService {
 
   private final UserRepository userRepository;
 

--- a/src/test/java/nl/hr/recipefinder/controller/RecipeControllerTests.java
+++ b/src/test/java/nl/hr/recipefinder/controller/RecipeControllerTests.java
@@ -7,16 +7,12 @@ import nl.hr.recipefinder.model.dto.UserResponseDto;
 import nl.hr.recipefinder.model.entity.Recipe;
 import nl.hr.recipefinder.model.entity.User;
 import nl.hr.recipefinder.model.httpexception.clienterror.HttpNotFoundError;
-import nl.hr.recipefinder.model.httpexception.servererror.HttpInternalServerError;
 import nl.hr.recipefinder.security.Role;
 import nl.hr.recipefinder.service.RecipeService;
-import nl.hr.recipefinder.service.SessionService;
-import org.junit.jupiter.api.BeforeEach;
+import nl.hr.recipefinder.service.AuthenticationService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,7 +42,7 @@ public class RecipeControllerTests {
   RecipeService recipeService;
 
   @MockBean
-  SessionService sessionService;
+  AuthenticationService authenticationService;
 
   @MockBean
   ModelMapper modelMapper;
@@ -114,7 +110,7 @@ public class RecipeControllerTests {
       "Boil the chicken" ,2 , List.of(), List.of(), List.of(), List.of(), List.of(), new User("a", "a", Role.USER));
     RecipeDto recipeDto = new RecipeDto(1, "Tasty Chicken", "Very tasty chicken", 25,
       "Boil the chicken" ,2 , new UserResponseDto(), List.of(), List.of(), List.of(), List.of());
-    Mockito.when(sessionService.getAuthenticatedUser()).thenReturn(new User("a", "a", Role.USER));
+    Mockito.when(authenticationService.getAuthenticatedUser()).thenReturn(new User("a", "a", Role.USER));
     Mockito.when(modelMapper.map(recipeDto, Recipe.class)).thenReturn(recipe);
 
     // act
@@ -122,7 +118,7 @@ public class RecipeControllerTests {
 
     //assert
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-    verify(sessionService, times(1)).getAuthenticatedUser();
+    verify(authenticationService, times(1)).getAuthenticatedUser();
     verify(modelMapper, times(1)).map(recipeDto, Recipe.class);
   }
 }


### PR DESCRIPTION
Did a sweep through the controllers and endpoints.

- made some endpoints transactional. FYI the idea behind a transaction is that a set of changes to the entities in the database are made as _atomic_, meaning all the changes either completely fail or succeed: no partial changes to entities go through if one of the changes fails. This is relevant when saving multiple entities in one go and when updating an entity (patches, posts mostly). It gives a better guarantee of a proper state.
- used Lombok's constructor annotation in every controller, improving consistency and readability
- changed session endpoint to auth endpoint in both front end and back end to better reflect its actual functionality 