### PR TITLE
Changed add favorite recipe from post to patch since we are not creat…

### DIFF
--- a/src/app/service/favorites-list.service.ts
+++ b/src/app/service/favorites-list.service.ts
@@ -26,6 +26,6 @@ export class FavoritesListService {
   public addToList(recipeId: bigint, listId: bigint, headers) : Observable<FavoritesList> {
     let userId = this.authService.getUserId();
     let url = this.favoriteListsUrl + "/"+userId+"/favorites/" + listId;
-    return this.http.post<FavoritesList>(url, recipeId, {headers: headers});
+    return this.http.patch<FavoritesList>(url, recipeId, {headers: headers});
   }
 }

--- a/src/main/java/nl/hr/recipefinder/controller/FavoritesListController.java
+++ b/src/main/java/nl/hr/recipefinder/controller/FavoritesListController.java
@@ -56,7 +56,7 @@ public class FavoritesListController {
   }
 
   @Transactional
-  @PostMapping("/user/{userId}/favorites/{favoritesListId}")
+  @PatchMapping("/user/{userId}/favorites/{favoritesListId}")
   public ResponseEntity<FavoritesListResponseDto> addFavorite(@RequestBody Long recipeId, @PathVariable("userId") Long userId, @PathVariable("favoritesListId") Long favoritesListId) {
     try {
       User activeUser = authenticationService.getAuthenticatedUser();


### PR DESCRIPTION
Small fix in interest of properly applying rest principles:
- Add favorite recipe should be a PATCH since we are not creating a new resource but updating a part of an existing one (list of recipes is a property of favoriteslist)

For whoever changed this to POST :) see https://www.restapitutorial.com/lessons/httpmethods.html 